### PR TITLE
ci: aggregate per-cell asset manifests into armbian-sdk-images.json

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -50,7 +50,7 @@ jobs:
           armbian_branch:             "main"
           armbian_ui:                 "minimal"
           armbian_extensions:         "docker-ce,sdk${{ matrix.extension }}" # enable extensions
-          armbian_release_tittle:     "Armbian SDK"                          # release tittle
+          armbian_release_title:      "Armbian SDK"                          # release title
           armbian_release_tag:        "${{ github.run_id }}"
           armbian_release_body:       "Virtual images for x86 and arm64"     # release body
           armbian_pgp_key:            "${{ secrets.GPG_KEY1 }}"              # key for signing

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -71,16 +71,17 @@ jobs:
       contents: write
     steps:
 
-      - name: Download per-cell manifests from the release
+      - name: Download per-image manifests from the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p manifests
-          # Each Matrix cell uploads `assets-<board>-<release>-<branch>-<ui>.json`
-          # via the build action's manifest step. Pull all of them.
+          # The build action writes one `<image_filename>.assets.json` per
+          # image artefact (raw + .img.qcow2 + .img.vhdx all coexist when
+          # an image-output-* extension is enabled). Pull all of them.
           gh release download "${{ github.run_id }}" \
-            --pattern 'assets-*.json' \
+            --pattern '*.assets.json' \
             --dir manifests \
             --repo "${{ github.repository }}"
           ls -la manifests/

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -86,17 +86,17 @@ jobs:
             --repo "${{ github.repository }}"
           ls -la manifests/
 
-      - name: Merge into a single armbian-sdk-images.json
+      - name: Merge into a single armbian-images.json
         run: |
           set -euo pipefail
-          jq -s 'map(.assets) | flatten | {assets: .}' manifests/*.json > armbian-sdk-images.json
-          echo "Merged assets: $(jq '.assets | length' armbian-sdk-images.json)"
-          jq '.assets[] | "\(.board_slug) \(.distro)/\(.branch) \(.variant) \(.file_extension)"' armbian-sdk-images.json | head -20
+          jq -s 'map(.assets) | flatten | {assets: .}' manifests/*.json > armbian-images.json
+          echo "Merged assets: $(jq '.assets | length' armbian-images.json)"
+          jq '.assets[] | "\(.board_slug) \(.distro)/\(.branch) \(.variant) \(.file_extension)"' armbian-images.json | head -20
 
       - name: Upload merged manifest to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.run_id }}" armbian-sdk-images.json \
+          gh release upload "${{ github.run_id }}" armbian-images.json \
             --clobber \
             --repo "${{ github.repository }}"

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -36,7 +36,10 @@ jobs:
     name: "${{ matrix.os }},${{ matrix.board }}${{ matrix.extension }}"
     steps:
 
-      - uses: armbian/build@main
+      # NOTE: temporarily pinned to armbian/build PR #9772 branch so this PR
+      # (and its aggregator) can be tested end-to-end before #9772 lands.
+      # Switch back to @main once that PR is merged.
+      - uses: armbian/build@action-release-assets-manifest
         with:
           # mandatory
           armbian_token:              "${{ secrets.GITHUB_TOKEN }}"          # GitHub installation access token
@@ -52,6 +55,12 @@ jobs:
           armbian_release_body:       "Virtual images for x86 and arm64"     # release body
           armbian_pgp_key:            "${{ secrets.GPG_KEY1 }}"              # key for signing
           armbian_pgp_password:       "${{ secrets.GPG_PASSPHRASE1 }}"       # password for key
+          # SDK images publish to this repo's GitHub release, not dl.armbian.com.
+          # Empty `armbian_download_repository` selects the flat URL shape
+          # `<base>/<filename>` and clears the redi_url* fields (no friendly-
+          # redirect convention exists for GitHub releases).
+          armbian_download_base_url:  "https://github.com/${{ github.repository }}/releases/download/${{ github.run_id }}"
+          armbian_download_repository: ""
 
   Aggregate:
     name: "Aggregate per-cell asset manifests"

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -52,3 +52,41 @@ jobs:
           armbian_release_body:       "Virtual images for x86 and arm64"     # release body
           armbian_pgp_key:            "${{ secrets.GPG_KEY1 }}"              # key for signing
           armbian_pgp_password:       "${{ secrets.GPG_PASSPHRASE1 }}"       # password for key
+
+  Aggregate:
+    name: "Aggregate per-cell asset manifests"
+    needs: Matrix
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+
+      - name: Download per-cell manifests from the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p manifests
+          # Each Matrix cell uploads `assets-<board>-<release>-<branch>-<ui>.json`
+          # via the build action's manifest step. Pull all of them.
+          gh release download "${{ github.run_id }}" \
+            --pattern 'assets-*.json' \
+            --dir manifests \
+            --repo "${{ github.repository }}"
+          ls -la manifests/
+
+      - name: Merge into a single armbian-sdk-images.json
+        run: |
+          set -euo pipefail
+          jq -s 'map(.assets) | flatten | {assets: .}' manifests/*.json > armbian-sdk-images.json
+          echo "Merged assets: $(jq '.assets | length' armbian-sdk-images.json)"
+          jq '.assets[] | "\(.board_slug) \(.distro)/\(.branch) \(.variant) \(.file_extension)"' armbian-sdk-images.json | head -20
+
+      - name: Upload merged manifest to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.run_id }}" armbian-sdk-images.json \
+            --clobber \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Pairs with [`armbian/build` #9772](https://github.com/armbian/build/pull/9772), which makes the composite `armbian/build@main` action emit a per-cell `assets-<board>-<release>-<branch>-<ui>.json` next to every image upload.

This SDK matrix runs 8 parallel cells (board × os × extension) into a single GitHub release tagged `${{ github.run_id }}`. With #9772 each cell will already write its own manifest fragment to that release. This PR adds a follow-up `Aggregate` job that merges them into a single `armbian-sdk-images.json`.

## What it does

After `Matrix` finishes:

1. `gh release download` pulls every `assets-*.json` attached to the run-id release.
2. `jq -s 'map(.assets) | flatten | {assets: .}'` merges them into one `{assets: [...]}` document.
3. The merged file is uploaded back to the release as `armbian-sdk-images.json` (`--clobber` so re-runs replace it).
4. The per-cell fragments are left in place — individual cells stay inspectable; the merged file is purely additive on top.

`if: always() && !cancelled()` keeps the aggregator running when one matrix cell fails (the matrix already has `fail-fast: false`), so partial inventories still publish.

## Test plan

- [ ] After both PRs land, trigger the SDK workflow and confirm the resulting GitHub release contains:
  - 8 per-cell `assets-*.json` (one per matrix cell)
  - 1 merged `armbian-sdk-images.json`
- [ ] `jq '.assets | length' armbian-sdk-images.json` should equal the sum of `.assets | length` across the per-cell files.
- [ ] Force a single matrix cell to fail; aggregator should still publish a manifest covering the cells that succeeded.