### PR TITLE
userpatches: pre-install gh + first-boot provisioning stub

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Armbian build hook — runs inside the rootfs chroot at image build time,
+# after packages are installed and before the image is packaged.
+# Use this file to pre-install packages, drop configs into place, stage
+# first-boot scripts at /root/provisioning.sh, etc.
+#
+# `userpatches/overlay/` is bind-mounted read-only at `/tmp/overlay/`
+# inside the chroot.
+#
+set -euo pipefail
+
+apt-get install -y --no-install-recommends gh
+install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh

--- a/userpatches/overlay/provisioning.sh
+++ b/userpatches/overlay/provisioning.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Generic post-firstlogin hook. Armbian's first-boot mechanism runs
+# /root/provisioning.sh once after firstboot.conf has applied its
+# PRESET_* settings (network, locale, root password, …) and the
+# initial login completes. Drop any custom setup work here.
+# Current body is a stub that just leaves a marker file behind.
+#
+set -euo pipefail
+date -u -Iseconds > /provisioned


### PR DESCRIPTION
## Summary

Two new userpatch files that wire up an automatic first-boot hook on the SDK image:

- **`userpatches/customize-image.sh`** — runs in the rootfs chroot at the end of build:
  1. Adds the official `cli.github.com` apt repo and installs `gh` (GitHub CLI) so SDK images ship with it ready out of the box.
  2. Copies `userpatches/overlay/provisioning.sh` to `/root/provisioning.sh` (executable). Armbian's existing first-boot mechanism runs that script once on first login — same pattern used by armbian-config's [`module_armbian_kvmtest`](https://github.com/armbian/configng/blob/main/tools/modules/system/module_armbian_kvmtest.sh#L215-L220). No bespoke systemd unit, no done-marker logic.

- **`userpatches/overlay/provisioning.sh`** — placeholder body for now. Just writes `/provisioned` with a UTC timestamp so the install path can be verified end-to-end. Replace with real provisioning when ready.

## How the wiring works

The build framework's [`lib/functions/rootfs/customize.sh`](https://github.com/armbian/build/blob/main/lib/functions/rootfs/customize.sh) bind-mounts `userpatches/overlay/` read-only at `/tmp/overlay/` inside the chroot, then runs `customize-image.sh`. The hook does:

```bash
install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh
```

The existing Armbian first-boot mechanism takes it from there.

## Test plan

- [ ] Trigger the SDK build workflow.
- [ ] Confirm `gh` is preinstalled in the booted image (`gh --version`).
- [ ] Confirm `/provisioned` exists after first login, with a UTC timestamp inside.
- [ ] Confirm the script does not run again on subsequent logins.