### PR TITLE
userpatches: switch pre-install from gh to git

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -10,5 +10,6 @@
 #
 set -euo pipefail
 
-apt-get install -y --no-install-recommends gh
+apt-get update
+apt-get install -y --no-install-recommends git
 install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh


### PR DESCRIPTION
## Summary

Two fixes to the build hook merged in #14:

1. **`gh` → `git`** — GitHub CLI (`gh`) isn't carried in the Armbian apt repo, so the original `apt-get install gh` failed inside the chroot. Drop back to plain `git`, which is available out of the box on every supported release.
2. **Add `apt-get update`** — the build framework clears `/var/lib/apt/lists/` between rootfs creation and `customize-image.sh`, so without an explicit refresh apt has no package data and even `git` fails with `Package 'git' has no installation candidate`.

Follow-up to #14.