### PR TITLE
Pre-load SDK images with build framework, code-server, Python + Claude Code, and SSH keys

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -36,10 +36,7 @@ jobs:
     name: "${{ matrix.os }},${{ matrix.board }}${{ matrix.extension }}"
     steps:
 
-      # NOTE: temporarily pinned to armbian/build PR #9772 branch so this PR
-      # (and its aggregator) can be tested end-to-end before #9772 lands.
-      # Switch back to @main once that PR is merged.
-      - uses: armbian/build@action-release-assets-manifest
+      - uses: armbian/build@main
         with:
           # mandatory
           armbian_token:              "${{ secrets.GITHUB_TOKEN }}"          # GitHub installation access token
@@ -48,11 +45,40 @@ jobs:
           armbian_board:              "${{ matrix.board }}"                  # board build target
           # optional
           armbian_branch:             "main"
+          armbian_kernel_branch:      "cloud"                                # cloud kernel: smaller, no SBC drivers
           armbian_ui:                 "minimal"
-          armbian_extensions:         "docker-ce,sdk${{ matrix.extension }}" # enable extensions
+          armbian_extensions:         "sdk${{ matrix.extension }}"           # enable extensions
           armbian_release_title:      "Armbian SDK"                          # release title
           armbian_release_tag:        "${{ github.run_id }}"
-          armbian_release_body:       "Virtual images for x86 and arm64"     # release body
+          armbian_release_prerelease: "true"                                    # promoted to a full release by the Aggregate job
+          armbian_release_body:       |                                       # release body
+            Armbian SDK — daily virtual images preloaded with the Armbian development environment.
+
+            ### Targets
+
+            x86 (`uefi-x86`) and arm64 (`uefi-arm64`), built on Ubuntu `noble` and Debian `trixie`, using the `cloud` kernel.
+
+            ### Formats
+
+            Raw `.img.xz` and `.img.qcow2`.
+
+            ### Inside the image
+
+            - **Curated Armbian source tree** pre-cloned into the code-server workspace at `/armbian/code-server/config/workspace/` (`build`, `configng`, `documentation`, `website`, `imager`).
+
+            - **Build dependencies pre-installed.** `./compile.sh requirements` has already run inside the rootfs, so the first build skips the apt phase.
+
+            - **code-server** (browser VS Code) installed on first boot, with the Python extension and the Claude Code CLI pre-provisioned.
+
+            - **SSH ready out of the box.** Maintainer's GitHub public keys baked into both `root` and the `armbian` user via Armbian's `PRESET_*_KEY` firstboot mechanism.
+
+            ### Defaults
+
+            Credentials `armbian` / `armbian`. code-server on port `8443`.
+
+            ### Manifest
+
+            `armbian-images.json` (aggregated across the matrix) and `<image>.assets.json` (per-image) are published alongside the assets for programmatic consumption.
           armbian_pgp_key:            "${{ secrets.GPG_KEY1 }}"              # key for signing
           armbian_pgp_password:       "${{ secrets.GPG_PASSPHRASE1 }}"       # password for key
           # SDK images publish to this repo's GitHub release, not dl.armbian.com.
@@ -99,4 +125,19 @@ jobs:
         run: |
           gh release upload "${{ github.run_id }}" armbian-images.json \
             --clobber \
+            --repo "${{ github.repository }}"
+
+      # Matrix builds publish to GitHub as a pre-release so partial /
+      # in-flight runs aren't surfaced as `latest`. Once the matrix is
+      # green and the aggregated manifest is in place, flip the release
+      # to a normal release. If any matrix cell failed, leave it as a
+      # pre-release so the broken state is visible.
+      - name: Promote release (matrix succeeded)
+        if: ${{ needs.Matrix.result == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ github.run_id }}" \
+            --prerelease=false \
+            --latest \
             --repo "${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -1,22 +1,39 @@
-<h2 align="center">
+<h3 align="center">
   <a href=#><img src="https://raw.githubusercontent.com/armbian/.github/master/profile/logosmall.png" alt="Armbian logo"></a>
   <br><br>
-</h2>
+</h3>
 
+## Purpose of This Repository
 
+The **Armbian SDK** publishes ready-to-deploy **Armbian** virtual images preloaded with the toolchain, source repositories, and dependencies needed to develop on the Armbian platform — drop one onto a cloud provider, **Proxmox**, or any **QEMU/KVM**-capable hypervisor and start building immediately.
 
-## What does this project do?
+Daily builds from this repository's [GitHub Action](.github/workflows/action.yml) target **`uefi-x86`** and **`uefi-arm64`** on **Ubuntu Noble** and **Debian Trixie** with the **`cloud`** kernel, published as raw `.img.xz` and `.img.qcow2`.
 
-- provide daily live x86 / arm64 `Armbian Jammy` builds with preinstalled `Docker`
-- provides images in raw `ISO` and `qcow2` virtual disks format
-- shows example of [Armbian GitHub action](.github/workflows/action.yml) for making custom images
+> **Looking for SBC images?** Use [Armbian Imager](https://github.com/armbian/imager/releases) — these images are virtual machines, not SBC images.
 
-## To-do list
+## Quick Start
 
-- [x] can be made daily / weekly
-- [x] preinstalled Docker
-- [x] automated login into user `armbian`
-- [ ] pre-loaded with latest build script
-- [ ] contains all kernel caches
+Download a `.img.qcow2` from the [latest release](https://github.com/armbian/sdk/releases/latest) and boot it under any QEMU/KVM-capable hypervisor.
 
-Jira ticket: [[AR-1459](https://armbian.atlassian.net/browse/AR-1459)]
+- **Default credentials:** `armbian` / `armbian` (configured in [userpatches/firstboot.conf](userpatches/firstboot.conf))
+- **code-server** (browser-based VS Code) on port `8443`
+- **Build framework** checked out at `~/workspace/build`
+
+## What's Inside
+
+- **Curated source tree** pre-cloned into the code-server workspace at `/armbian/code-server/config/workspace/` (linked at `~/workspace` for shell users): [build](https://github.com/armbian/build), [configng](https://github.com/armbian/configng), [documentation](https://github.com/armbian/documentation), [website](https://github.com/armbian/website), [imager](https://github.com/armbian/imager).
+- **Build dependencies** pre-installed (`./compile.sh requirements` already ran in the rootfs) — the first build skips the apt phase.
+- **[code-server](https://coder.com/docs/code-server)** installed on first boot via `armbian-config --api module_code-server install`, with the **Python** extension (`ms-python.python`) pre-installed and the **[Claude Code](https://docs.claude.com/en/docs/claude-code)** CLI available in the integrated terminal.
+- **SSH ready out of the box**: maintainer's GitHub public keys baked into both `root` and the `armbian` user via Armbian's `PRESET_*_KEY` firstboot mechanism.
+- **Asset manifest** at a stable URL for programmatic consumption: <https://github.com/armbian/sdk/releases/latest/download/armbian-images.json>.
+
+## How It's Built
+
+The [GitHub Action](.github/workflows/action.yml) drives a `{board} × {release} × {extension}` matrix through the [armbian/build](https://github.com/armbian/build) composite action. Each cell runs the build chroot's [customize-image.sh](userpatches/customize-image.sh) (clones, build deps, key seeding) and stages [provisioning.sh](userpatches/overlay/provisioning.sh) for first boot (code-server install, extension provisioning, ownership handover). After the matrix completes, an aggregator job merges per-image manifests into a single `armbian-images.json` and promotes the release from pre-release to latest.
+
+## Resources
+
+- **[Armbian Documentation](https://docs.armbian.com/Developer-Guide_Overview/)** — Building, configuring, and customizing
+- **[Armbian Build Framework](https://github.com/armbian/build)** — The framework this SDK targets
+- **[Website](https://www.armbian.com)** — News, features, and board information
+- **[Forums](https://forum.armbian.com)** — Community support and discussions

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -13,3 +13,27 @@ set -euo pipefail
 apt-get update
 apt-get install -y --no-install-recommends git
 install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh
+
+# Clone a small set of armbian-org repos directly into code-server's
+# workspace so they appear at /config/workspace/<repo> in the IDE. The
+# heavier repos (firmware, armbian.github.io, sdk, docker-armbian-build)
+# are left for the user to clone on demand to keep the image under
+# GitHub's 2 GiB per-asset release cap. code-server itself is installed
+# at first boot (provisioning.sh) since the Docker daemon does not run
+# inside the build chroot.
+REPOS=(
+    build
+    configng
+    documentation
+    website
+    imager
+)
+WORKSPACE=/armbian/code-server/config/workspace
+mkdir -p "$WORKSPACE"
+for repo in "${REPOS[@]}"; do
+    git clone "https://github.com/armbian/${repo}.git" "${WORKSPACE}/${repo}"
+done
+
+# Install build host deps now (apt installs land in the chroot's rootfs).
+( cd "${WORKSPACE}/build" && ./compile.sh requirements )
+apt-get clean

--- a/userpatches/firstboot.conf
+++ b/userpatches/firstboot.conf
@@ -7,11 +7,11 @@ PRESET_TIMEZONE="Etc/UTC"
 
 # Root
 PRESET_ROOT_PASSWORD="armbian"
-PRESET_ROOT_KEY=""
+PRESET_ROOT_KEY="https://github.com/igorpecovnik.keys"
 
 # User
 PRESET_USER_NAME="armbian"
 PRESET_USER_PASSWORD="armbian"
-PRESET_USER_KEY=""
+PRESET_USER_KEY="https://github.com/igorpecovnik.keys"
 PRESET_DEFAULT_REALNAME="Armbian user"
 PRESET_USER_SHELL="bash"

--- a/userpatches/overlay/provisioning.sh
+++ b/userpatches/overlay/provisioning.sh
@@ -2,9 +2,36 @@
 #
 # Generic post-firstlogin hook. Armbian's first-boot mechanism runs
 # /root/provisioning.sh once after firstboot.conf has applied its
-# PRESET_* settings (network, locale, root password, …) and the
-# initial login completes. Drop any custom setup work here.
-# Current body is a stub that just leaves a marker file behind.
+# PRESET_* settings (network, locale, root password, the `armbian`
+# user, …) and the initial login completes. Runs as root.
+#
+# customize-image.sh has already cloned every relevant armbian-org repo
+# straight into code-server's workspace at /armbian/code-server/config/
+# workspace/ at build time. Single source of truth — this hook just
+# hands ownership to the armbian user and surfaces a convenience
+# symlink in the user's home.
 #
 set -euo pipefail
+
+USER_NAME="armbian"
+USER_HOME="/home/${USER_NAME}"
+
+# Docker daemon is up now (it wasn't in the build chroot), so the
+# code-server container install can run normally.
+armbian-config --api module_code-server install
+
+# Wait for the code-server binary to be reachable inside the container,
+# then provision the Python extension and the Claude Code CLI so the
+# IDE is usable out of the box. The first `claude` run inside the
+# code-server integrated terminal offers to install the matching VS
+# Code extension automatically.
+while ! docker exec code-server which code-server >/dev/null 2>&1; do
+    sleep 2
+done
+docker exec -u abc code-server code-server --install-extension ms-python.python
+docker exec code-server bash -lc "npm install -g @anthropic-ai/claude-code"
+
+chown -R "${USER_NAME}:${USER_NAME}" /armbian/code-server/config
+ln -s /armbian/code-server/config/workspace "${USER_HOME}/workspace"
+
 date -u -Iseconds > /provisioned


### PR DESCRIPTION
## Summary

Turns the SDK image into a ready-to-deploy Armbian development environment. Boot a `.img.qcow2` on a cloud provider, Proxmox, or any QEMU/KVM-capable hypervisor and start building immediately — no host setup, no toolchain hunt.

Closely paired with [armbian/build #9772](https://github.com/armbian/build/pull/9772) (assets manifest + new `armbian_release_prerelease` input) and [armbian/armbian.github.io #306](https://github.com/armbian/armbian.github.io/pull/306) (third-party manifest merge into the canonical index).

## What ships in the image

- **Curated source tree pre-cloned at build time** into the code-server workspace at `/armbian/code-server/config/workspace/`, surfaced at `~/workspace/<repo>` for shell users:
  - `build`, `configng`, `documentation`, `website`, `imager`
  - The heavier repos (firmware, armbian.github.io, sdk, docker-armbian-build) are intentionally left out so the compressed image stays under GitHub's 2 GiB per-asset release cap.
- **Build dependencies pre-installed** — `./compile.sh requirements` is executed inside the build chroot, then `apt-get clean` drops the cache. First build skips the apt phase.
- **code-server** (browser VS Code) installed on first boot via `armbian-config --api module_code-server install`. Runs as a Docker container; that's why install is deferred — the build chroot has no Docker daemon.
  - **Python extension** (`ms-python.python`) installed inside the container.
  - **Claude Code CLI** (`@anthropic-ai/claude-code`) installed inside the container so `claude` is on the integrated terminal's PATH.
- **SSH ready out of the box** — maintainer's GitHub public keys are baked into both `root` and the `armbian` user via Armbian's `PRESET_*_KEY` firstboot mechanism. See [`userpatches/firstboot.conf`](userpatches/firstboot.conf).
- **Cloud kernel** instead of current — smaller, no SBC drivers, fits the VM use case.
- **Defaults**: credentials `armbian` / `armbian`; code-server on port `8443`.

## CI / release flow changes

- Releases are created as **pre-releases** while the matrix is still uploading, then promoted to `--latest` only after the `Aggregate` job sees `needs.Matrix.result == 'success'`. Partial-failure runs stay flagged as pre-releases.
- `artifactErrorsFailBuild` is on (via the build action), so any individual asset upload failure (including hitting GitHub's 2 GiB per-asset cap) fails the cell loudly instead of being a silent warning.
- The aggregator merges per-image manifests into a single [`armbian-images.json`](https://github.com/armbian/sdk/releases/latest/download/armbian-images.json), published as a release asset at a stable URL. That URL is what the third-party-merge PR on `armbian.github.io` consumes.
- Release body and `README.md` rewritten to describe what the image actually is.

## What runs where

**Build chroot (root, no Docker daemon)** — [`userpatches/customize-image.sh`](userpatches/customize-image.sh):

```sh
apt-get update
apt-get install -y --no-install-recommends git curl
install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh

REPOS=(build configng documentation website imager)
WORKSPACE=/armbian/code-server/config/workspace
mkdir -p "$WORKSPACE"
for repo in "${REPOS[@]}"; do
    git clone "https://github.com/armbian/${repo}.git" "${WORKSPACE}/${repo}"
done

( cd "${WORKSPACE}/build" && ./compile.sh requirements )
apt-get clean
```

**First boot (root, after firstboot.conf has created the `armbian` user and seeded its SSH keys)** — [`userpatches/overlay/provisioning.sh`](userpatches/overlay/provisioning.sh):

```sh
armbian-config --api module_code-server install

while ! docker exec code-server which code-server >/dev/null 2>&1; do
    sleep 2
done
docker exec -u abc code-server code-server --install-extension ms-python.python
docker exec code-server bash -lc "npm install -g @anthropic-ai/claude-code"

chown -R armbian:armbian /armbian/code-server/config
ln -s /armbian/code-server/config/workspace /home/armbian/workspace
date -u -Iseconds > /provisioned
```

## Why these design choices

- **Single source of truth for the workspace.** Build-time clone, first-boot chown — never two copies.
- **Build chroot vs. first boot split.** Anything that needs the kernel / systemd / Docker runs on first boot. Anything else (apt, clones, requirements install) runs in the chroot and is part of the deterministic image.
- **Curated subset of repos.** Cloning all nine pushed the `.img.xz` over the 2 GiB GitHub release-asset cap. Five repos covers the day-one development surface; the user can `git clone` the rest on demand.
- **GitHub keys at firstboot, not at build time.** Uses the existing `PRESET_*_KEY` mechanism in `armbian-firstlogin` rather than duct-taping `/etc/skel/.ssh`.

## Test plan

- [x] Image boots under QEMU/KVM and on Proxmox.
- [x] code-server reachable on `:8443`; the file tree shows `build`, `configng`, `documentation`, `website`, `imager` with full git history.
- [x] `/home/armbian/workspace` is a symlink resolving to the cloned trees, owned by `armbian:armbian`.
- [x] Build deps already installed (`debootstrap`, `qemu-user-static`, `aptly`, …) — `./compile.sh requirements` is a no-op on the first run.
- [x] `claude` is on PATH inside code-server's integrated terminal; first run offers the matching VS Code extension.
- [x] Python extension is active in code-server.
- [x] `ssh root@<ip>` and `ssh armbian@<ip>` succeed using the maintainer's GitHub key, no password prompt.
- [x] Release is published as a pre-release while the matrix runs and promoted to `--latest` only after the aggregator merges manifests.
- [x] An over-2-GiB asset upload fails the cell (no longer a silent warning).
- [x] `https://github.com/armbian/sdk/releases/latest/download/armbian-images.json` resolves with the merged per-image manifests.