### PR TITLE
userpatches: pre-install tig, nodejs and Claude Code CLI host-side

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -11,8 +11,14 @@
 set -euo pipefail
 
 apt-get update
-apt-get install -y --no-install-recommends git
+apt-get install -y --no-install-recommends git tig nodejs npm
 install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh
+
+# Pre-install the Claude Code CLI host-side so `claude` is on the
+# armbian user's PATH from a plain SSH session too. (provisioning.sh
+# also installs it inside the code-server container so it shows up in
+# the IDE's integrated terminal — that's a separate npm install.)
+npm install -g @anthropic-ai/claude-code
 
 # Clone a small set of armbian-org repos directly into code-server's
 # workspace so they appear at /config/workspace/<repo> in the IDE. The


### PR DESCRIPTION
## Summary

Build-time additions to [`userpatches/customize-image.sh`](userpatches/customize-image.sh) so the SDK image ships with these ready on the host:

- **tig** — TUI git history / log / blame browser; useful in any terminal.
- **nodejs + npm** — host-side JS runtime + package manager for tooling people want to run from the shell.
- **`@anthropic-ai/claude-code`** — installed globally with `npm install -g`, so `claude` is on the `armbian` user's PATH from a plain SSH session.

## Relationship to provisioning.sh

`provisioning.sh` already installs Claude Code **inside** the code-server container at first boot, so it appears in the IDE's integrated terminal. This PR additionally installs it **on the host** so a regular SSH session into the VM also has it available. The two installs are independent — no shared state.

## Test plan

- [ ] Boot the SDK image. `which tig`, `which node`, `which npm`, `which claude` all resolve on the host.
- [ ] `claude --version` works without first asking the user to install anything.
- [ ] code-server's integrated terminal still has its own `claude` (installed by provisioning.sh inside the container).
- [ ] Image stays under GitHub's 2 GiB per-asset release cap.