### PR TITLE
userpatches: install zsh via armbian-config --api, not direct apt

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -11,8 +11,20 @@
 set -euo pipefail
 
 apt-get update
-apt-get install -y --no-install-recommends git tig nodejs npm armbian-zsh
+# armbian-zsh isn't installable directly at customize-image time —
+# the Armbian apt repo isn't yet wired up in the chroot, so apt
+# returns 'unable to locate package'. Install armbian-config instead
+# and then dispatch via its --api flag below; module_zsh handles the
+# repo plumbing and pulls armbian-zsh / zsh-common / zsh in one shot.
+apt-get install -y --no-install-recommends git tig nodejs npm armbian-config
 install -m 0755 /tmp/overlay/provisioning.sh /root/provisioning.sh
+
+# Install zsh via armbian-config's module_zsh. Pulls the armbian-zsh /
+# zsh-common / zsh package set, refreshes /etc/skel from the matching
+# dotfiles, and flips root's login shell to /bin/zsh — the full
+# Armbian-flavoured setup. Same `armbian-config --api module_<name>
+# <verb>` invocation pattern provisioning.sh uses for module_code-server.
+armbian-config --api module_zsh install
 
 # Pre-install the Claude Code CLI host-side so `claude` is on the
 # armbian user's PATH from a plain SSH session too. (provisioning.sh


### PR DESCRIPTION
## Summary
Direct `apt-get install armbian-zsh` at customize-image time fails — the Armbian apt repo isn't yet wired up in the chroot, so apt returns `unable to locate package` and the build aborts under `set -euo pipefail`.

This PR swaps the approach:
- Drop `armbian-zsh` from the apt-install line.
- Add `armbian-config` to that line so the dispatcher resolves.
- Run `armbian-config --api module_zsh install` right after, which handles the repo plumbing internally.

## Why this works
`module_zsh install` in configng pulls `armbian-zsh` / `zsh-common` / `zsh` in one shot, refreshes `/etc/skel` from the matching dotfiles, and flips root's login shell to `/bin/zsh` — the full Armbian-flavoured setup. Same `armbian-config --api module_<name> <verb>` invocation pattern [`provisioning.sh`](userpatches/overlay/provisioning.sh) already uses for `module_code-server`.

Reverts the post-merge edit that put `armbian-zsh` directly in the apt list and restores the api-based path PR #19 originally introduced.

## Test plan
- [ ] Build an SDK image and confirm the customize-image step doesn't fail on the apt-install line.
- [ ] On the resulting image, `zsh --version` reports a version.
- [ ] `getent passwd root | awk -F: '{print $7}'` returns `/bin/zsh`.
- [ ] `/etc/skel` contains the armbian-zsh dotfiles.