### PR TITLE
ci: dispatch armbian.github.io download-index regen after green build

### DIFF
--- a/.github/workflows/infrastructure-dispatch-download-index.yml
+++ b/.github/workflows/infrastructure-dispatch-download-index.yml
@@ -1,0 +1,51 @@
+name: "Infrastructure: Dispatch download index update"
+run-name: Dispatch armbian.github.io download-index after ${{ github.event.workflow_run.name || github.workflow }}
+
+# Watches for the SDK build workflow to finish, then fires a
+# repository_dispatch at armbian/armbian.github.io so the download
+# index is regenerated against the freshly published SDK release.
+# Mirrors the peter-evans/repository-dispatch pattern already used
+# by armbian/build (data-sync-board-list.yml) and by the
+# infrastructure-dispatch-to-fork helper.
+on:
+  workflow_run:
+    workflows: ["Build Armbian SDK"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: 📢 Trigger download-index regen
+    runs-on: ubuntu-latest
+    # Only fire from the canonical repo (skip forks) AND only when
+    # the upstream build actually succeeded — partial / red matrix
+    # runs leave the release as pre-release and the index would
+    # regenerate against incomplete data. Manual workflow_dispatch
+    # is always allowed for one-off retries.
+    if: >-
+      ${{ github.repository_owner == 'armbian'
+          && (github.event_name == 'workflow_dispatch'
+              || github.event.workflow_run.conclusion == 'success') }}
+    env:
+      DISPATCH_SECRET: ${{ secrets.ACCESS_TOKEN }}
+    steps:
+      - name: Fire repository_dispatch on armbian/armbian.github.io
+        # Soft-skip when the secret isn't configured (e.g. on a fresh
+        # repo clone before the maintainer has wired ACCESS_TOKEN)
+        # rather than failing red.
+        if: ${{ env.DISPATCH_SECRET != '' }}
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ env.DISPATCH_SECRET }}
+          repository: armbian/armbian.github.io
+          event-type: "Data: Update download index"
+          client-payload: >-
+            {
+              "source_workflow": "${{ github.event.workflow_run.name || github.workflow }}",
+              "source_run_id":   "${{ github.event.workflow_run.id   || github.run_id }}",
+              "source_repo":     "${{ github.repository }}",
+              "source_sha":      "${{ github.event.workflow_run.head_sha || github.sha }}"
+            }


### PR DESCRIPTION
## Summary
After [`Build Armbian SDK`](.github/workflows/action.yml) finishes, fire a `repository_dispatch` at [`armbian/armbian.github.io`](https://github.com/armbian/armbian.github.io/actions/workflows/data-update-download-index.yml) so the download index regenerates against the freshly promoted SDK release.

Same shape `armbian/build` already uses — [`infrastructure-dispatch-to-fork.yml`](https://github.com/armbian/build/blob/main/.github/workflows/infrastructure-dispatch-to-fork.yml) and [`data-sync-board-list.yml`](https://github.com/armbian/build/blob/main/.github/workflows/data-sync-board-list.yml) — `peter-evans/repository-dispatch@v4` + `ACCESS_TOKEN` org PAT.

## Behaviour matrix

| Trigger                                 | Owner       | Upstream conclusion | Secret set | Action |
|-----------------------------------------|-------------|---------------------|------------|--------|
| `workflow_run` after `Build Armbian SDK`| `armbian`   | `success`           | yes        | dispatch |
| same                                    | `armbian`   | `success`           | no         | step soft-skips |
| same                                    | `armbian`   | failure / cancelled | —          | job skipped (`if`) |
| same                                    | fork owner  | any                 | —          | job skipped (`if`) |
| Manual `workflow_dispatch`              | `armbian`   | n/a                 | yes        | dispatch |

## Why gate on `conclusion == 'success'`
The [`Aggregate`](.github/workflows/action.yml#L91) job leaves the release as a pre-release if any matrix cell failed. Regenerating the index against an incomplete release would surface partial assets to end users. Better to no-op until the matrix is green.

## Event type
`Data: Update download index` — matches the [listener at line 5](https://github.com/armbian/armbian.github.io/blob/master/.github/workflows/data-update-download-index.yml) of the target workflow.

## Test plan
- [ ] Merge to main; trigger a manual `workflow_dispatch` of this new workflow as a smoke test.
- [ ] Confirm the dispatch lands by watching `data-update-download-index` runs in the target repo.
- [ ] Trigger the SDK build workflow; verify this workflow runs after, fires only when the build succeeded, and the target workflow regenerates the index.
- [ ] Confirm a forked sdk repo running this workflow no-ops (no spurious dispatches at armbian.github.io).