### PR TITLE
ci: add Ubuntu resolute to the build matrix

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         board: ["uefi-x86","uefi-arm64"]
-        os: ["noble","trixie"]
+        os: ["noble","resolute","trixie"]
         extension: [",image-output-qcow2",""]
         include:
         - board: uefi-x86
@@ -56,7 +56,7 @@ jobs:
 
             ### Targets
 
-            x86 (`uefi-x86`) and arm64 (`uefi-arm64`), built on Ubuntu `noble` and Debian `trixie`, using the `cloud` kernel.
+            x86 (`uefi-x86`) and arm64 (`uefi-arm64`), built on Ubuntu (`noble`, `resolute`) and Debian (`trixie`), using the `cloud` kernel.
 
             ### Formats
 


### PR DESCRIPTION
## Summary
Add \`resolute\` to the OS matrix in [\`action.yml\`](.github/workflows/action.yml):

\`\`\`diff
-        os: [\"noble\",\"trixie\"]
+        os: [\"noble\",\"resolute\",\"trixie\"]
\`\`\`

Matrix grows from 2 boards × 2 OS × 2 ext = **8 cells** to 2 × 3 × 2 = **12 cells**. Updated the release body's Targets section to mention the new release.

## Test plan
- [ ] Trigger a manual \`workflow_dispatch\` of \`Build Armbian SDK\`.
- [ ] Confirm 12 matrix cells run (was 8).
- [ ] Confirm \`uefi-x86,resolute\` and \`uefi-arm64,resolute\` cells produce \`.img.xz\` and \`.img.qcow2\` artefacts on the release.
- [ ] Confirm the aggregated \`armbian-images.json\` contains entries for \`branch: resolute\`.