### PR TITLE
sdk: stop generating noble images

### DIFF
--- a/.github/workflows/build-armbian-sdk.yml
+++ b/.github/workflows/build-armbian-sdk.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         board: ["uefi-x86","uefi-arm64"]
-        os: ["noble","resolute","trixie"]
+        os: ["resolute","trixie"]
         extension: [",image-output-qcow2",""]
         include:
         - board: uefi-x86
@@ -56,7 +56,7 @@ jobs:
 
             ### Targets
 
-            x86 (`uefi-x86`) and arm64 (`uefi-arm64`), built on Ubuntu (`noble`, `resolute`) and Debian (`trixie`), using the `cloud` kernel.
+            x86 (`uefi-x86`) and arm64 (`uefi-arm64`), built on Ubuntu (`resolute`) and Debian (`trixie`), using the `cloud` kernel.
 
             ### Formats
 

--- a/userpatches/config-armbian-sdk.conf
+++ b/userpatches/config-armbian-sdk.conf
@@ -16,8 +16,4 @@ declare -g COMPRESS_OUTPUTIMAGE="sha,img,xz"
 declare -g IMAGE_XZ_COMPRESSION_RATIO=8
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-zsh,armbian-plymouth-theme"
 declare -g PREFER_DOCKER="yes"
-# Build inside Debian Trixie, the official build host. Without this the
-# framework falls back to its ubuntu:noble default. The framework turns this
-# into the matching prebuilt image, ghcr.io/armbian/docker-armbian-build:
-# armbian-debian-trixie-latest.
 declare -g DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie"

--- a/userpatches/config-armbian-sdk.conf
+++ b/userpatches/config-armbian-sdk.conf
@@ -16,3 +16,8 @@ declare -g COMPRESS_OUTPUTIMAGE="sha,img,xz"
 declare -g IMAGE_XZ_COMPRESSION_RATIO=8
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-zsh,armbian-plymouth-theme"
 declare -g PREFER_DOCKER="yes"
+# Build inside Debian Trixie, the official build host. Without this the
+# framework falls back to its ubuntu:noble default. The framework turns this
+# into the matching prebuilt image, ghcr.io/armbian/docker-armbian-build:
+# armbian-debian-trixie-latest.
+declare -g DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie"


### PR DESCRIPTION
Follow-up to the host switch to Armbian/Debian 13 (Trixie) — armbian/build#10494, armbian/documentation#974.

The SDK images exist to hand developers the supported build environment, so a noble variant is no longer wanted.

```diff
-        os: ["noble","resolute","trixie"]
+        os: ["resolute","trixie"]
```

Release body updated to match (it named `noble` and `resolute` as the Ubuntu targets).

Matrix goes from 12 images per run to 8: 2 releases × 2 boards × 2 formats.