### PR TITLE
ci: also publish an .iso from the SDK build

### DIFF
--- a/.github/workflows/build-armbian-sdk.yml
+++ b/.github/workflows/build-armbian-sdk.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         board: ["uefi-x86","uefi-arm64"]
         os: ["resolute","trixie"]
-        extension: [",image-output-qcow2",""]
+        extension: [",image-output-qcow2",",image-output-iso"]
         include:
         - board: uefi-x86
           runner: ubuntu-24.04
@@ -60,7 +60,7 @@ jobs:
 
             ### Formats
 
-            Raw `.img.xz` and `.img.qcow2`.
+            Raw `.img.xz`, `.img.qcow2`, and `.iso`.
 
             ### Inside the image
 


### PR DESCRIPTION
The `extension` matrix built each board/os pair twice — once with
`image-output-qcow2`, once bare (raw `.img.xz` only). This gives that
second, bare variant the **`image-output-iso`** extension instead, so the
SDK release now carries an **`.iso`** next to the raw and qcow2 images.

```yaml
-        extension: [",image-output-qcow2",""]
+        extension: [",image-output-qcow2",",image-output-iso"]
```

Raw `.img.xz` is still produced by *both* variants (it's the base output;
qcow2/iso are layered on), so no artifact is dropped. The manifest
download step already globs `*.assets.json`, so the iso's per-image
manifest is merged automatically. Release-body **Formats** line updated to
list `.iso`.