### PR TITLE
ci: upload SDK images to dl.armbian.com instead of GitHub releases

### DIFF
--- a/.github/workflows/build-armbian-sdk.yml
+++ b/.github/workflows/build-armbian-sdk.yml
@@ -60,7 +60,9 @@ jobs:
 
             ### Formats
 
-            Raw `.img.xz`, `.img.qcow2`, and `.iso`.
+            Raw `.img.xz`, `.img.qcow2`, and `.iso`. The images are hosted on
+            Armbian storage at <https://dl.armbian.com/sdk/> (too large for
+            GitHub release assets); this release carries only their manifests.
 
             ### Inside the image
 
@@ -78,15 +80,43 @@ jobs:
 
             ### Manifest
 
-            `armbian-images.json` (aggregated across the matrix) and `<image>.assets.json` (per-image) are published alongside the assets for programmatic consumption.
+            `armbian-images.json` (aggregated across the matrix) and `<image>.assets.json` (per-image) are published on this release for programmatic consumption; each manifest's `file_url` points at the image on <https://dl.armbian.com/sdk/>.
           armbian_pgp_key:            "${{ secrets.GPG_KEY1 }}"              # key for signing
           armbian_pgp_password:       "${{ secrets.GPG_PASSPHRASE1 }}"       # password for key
-          # SDK images publish to this repo's GitHub release, not dl.armbian.com.
-          # Empty `armbian_download_repository` selects the flat URL shape
-          # `<base>/<filename>` and clears the redi_url* fields (no friendly-
-          # redirect convention exists for GitHub releases).
-          armbian_download_base_url:  "https://github.com/${{ github.repository }}/releases/download/${{ github.run_id }}"
+          # The ~1.5 GiB images are too big for GitHub release storage, so they
+          # are rsync'd to dl.armbian.com below instead. Restrict the build
+          # action's own release upload to just the tiny per-image manifests
+          # (`*.assets.json`, needed by the Aggregate job) — the images, their
+          # checksums and signatures go to storage.
+          armbian_artifacts:          "build/output/images/*.assets.json"
+          # Download URLs in the manifests point at Armbian storage, where the
+          # images actually live. Empty `armbian_download_repository` selects the
+          # flat URL shape `<base>/<filename>` and clears the redi_url* fields
+          # (no friendly-redirect convention exists for the SDK area yet).
+          armbian_download_base_url:  "https://dl.armbian.com/sdk"
           armbian_download_repository: ""
+
+      # Ship the built images to Armbian's own storage (served at
+      # https://dl.armbian.com/sdk/). GitHub release storage can't hold a
+      # ~17 GiB/run matrix; only the small manifests stay on the release.
+      - name: "Install upload SSH key"
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
+        with:
+          key: ${{ secrets.KEY_UPLOAD }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS_ARMBIAN_UPLOAD }}
+          if_key_exists: replace
+
+      - name: "Upload images to dl.armbian.com storage"
+        run: |
+          set -euo pipefail
+          # Push the images + their .sha/.asc/.txt sidecars; the .assets.json
+          # manifests are excluded (they ride on the GitHub release instead).
+          # Filenames carry the version + board + variant, so parallel matrix
+          # cells never collide — no --delete, additive into the shared dir.
+          rsync -avh --exclude='*.assets.json' \
+            -e "ssh -p 10023 -o StrictHostKeyChecking=accept-new" \
+            build/output/images/ \
+            upload@rsync.armbian.com:/storage/www/dl/sdk/
 
   Aggregate:
     name: "Aggregate per-cell asset manifests"


### PR DESCRIPTION
### Problem

Each SDK matrix run publishes **~17 GiB** of images to a GitHub release
(12 cells × ~1.5 GiB `.img.xz` + `.img.qcow2.xz`, and now `.iso` on top of
that). That overruns GitHub's release/storage limits — on the latest run
the images **did not upload**.

### Fix — ship images the way the stable-image / live-patch CI already does

The `armbian/build` action uploads everything under `build/output/images/`
to a GitHub release. The other Armbian CIs instead rsync artifacts over SSH
to our own storage (`dl.armbian.com` → `/storage/www/dl/`). This makes the
SDK do the same:

- **Images → Armbian storage.** New `Install upload SSH key` +
  `Upload images to dl.armbian.com storage` steps rsync the built images
  (and their `.sha`/`.asc`/`.txt` sidecars) to
  `upload@rsync.armbian.com:/storage/www/dl/sdk/` (port 10023), served at
  <https://dl.armbian.com/sdk/>. Same `shimataro/ssh-key-action` +
  `rsync -e "ssh -p 10023 …"` pattern as `armbian/os`'s `live-patch.yml`
  and `webindex-update.yml`.
- **Release keeps only the manifests.** `armbian_artifacts` is narrowed to
  `build/output/images/*.assets.json`, so the per-image manifests (0 MiB)
  still land on the release for the **Aggregate** job — but the big images
  no longer touch GitHub storage.
- **Manifest URLs point at storage.** `armbian_download_base_url` →
  `https://dl.armbian.com/sdk`, so each manifest's `file_url` resolves to
  the real image location.

`armbian_artifacts` only feeds the release-upload glob in the action
(nothing in the build depends on it), so narrowing it is safe.

### 🔑 Secrets to add to this repo

| Secret | What it is |
|---|---|
| `KEY_UPLOAD` | SSH **private key** for the `upload@` storage account (same key `armbian/os` uses). |
| `KNOWN_HOSTS_ARMBIAN_UPLOAD` | `known_hosts` line for the upload host. |

`GPG_KEY1` / `GPG_PASSPHRASE1` are already used by this workflow, so no
change there.

### Open questions for review

- **Storage path** `/storage/www/dl/sdk/` and host `rsync.armbian.com` — is
  this the right target, or should SDK images live elsewhere / behind the
  redirector?
- **Retention.** Filenames carry the version, so daily builds accumulate in
  the dir (upload is additive, no `--delete`). Do we want a cleanup cron or
  a dated subdir?
- Should the GitHub release be kept at all (as a manifest index), or dropped
  entirely once images are on storage?