### PR TITLE
sdk: ship .iso and .img.qcow2 uncompressed

### DIFF
--- a/userpatches/config-armbian-sdk.conf
+++ b/userpatches/config-armbian-sdk.conf
@@ -13,6 +13,13 @@ declare -g COMPRESS_OUTPUTIMAGE="no"
 declare -g EXPERT="yes"
 declare -g KERNEL_BTF="yes"
 declare -g COMPRESS_OUTPUTIMAGE="sha,img,xz"
+# Ship the .iso and .img.qcow2 uncompressed (still checksummed). Both are
+# consumed as-is - the ISO is written/booted directly, the qcow2 is imported
+# straight into a hypervisor - so an .xz wrapper only forces an extra
+# decompress. The ISO's squashfs is already zstd-compressed (xz shaves ~3%),
+# and both formats sit under GitHub's 2 GiB asset cap uncompressed. The raw
+# .img keeps xz (SKIP_COMPRESSING matches the file's final extension only).
+declare -g SKIP_COMPRESSING="iso,qcow2"
 declare -g IMAGE_XZ_COMPRESSION_RATIO=8
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-zsh,armbian-plymouth-theme"
 declare -g PREFER_DOCKER="yes"


### PR DESCRIPTION
### Why

The `.iso` and `.img.qcow2` outputs are both consumed **as-is** — the ISO
is written/booted directly, the qcow2 is imported straight into a
hypervisor — so wrapping them in `.xz` just forces an extra decompress on
the user. And the compression barely helps: the ISO's squashfs is already
zstd-compressed, so xz shaved only **~3%** (1876 → 1824 MB) for several
minutes of CPU. Both formats sit **under GitHub's 2 GiB asset cap**
uncompressed, so nothing is gained by compressing them.

### Change

```diff
+ declare -g SKIP_COMPRESSING="iso,qcow2"
```

`SKIP_COMPRESSING` (build framework, `compress-checksum.sh`) leaves the
listed final-extensions **uncompressed but still checksummed**. Verified the
match logic: `.iso` and `.img.qcow2` → raw + `.sha`; the raw `.img` and
`.vhdx` still get xz. Config parses clean (`bash -n`).

### Depends on

**armbian/build#10495** — teaches the release-assets manifest generator to
recognise `.iso` (compressed *or* uncompressed) and the uncompressed
`.img.qcow2`, so both land in `armbian-images.json`. Without it the raw
`.iso` would ship but not appear in the JSON.

> Note: this trades the 2 GiB headroom for direct usability. If a future
> variant's uncompressed image ever crosses 2 GiB it would fail the GitHub
> upload — at which point drop that format from `SKIP_COMPRESSING` or move
> images to external storage.