### PR TITLE
ci: compress qcow2 again + move image builds to self-hosted runners

### DIFF
--- a/.github/workflows/build-armbian-sdk.yml
+++ b/.github/workflows/build-armbian-sdk.yml
@@ -29,10 +29,10 @@ jobs:
         extension: [",image-output-qcow2",",image-output-iso"]
         include:
         - board: uefi-x86
-          runner: ubuntu-24.04
+          runner: '[ "self-hosted", "fast", "X64" ]'
         - board: uefi-arm64
-          runner: ubuntu-22.04-arm
-    runs-on: ${{ matrix.runner }}
+          runner: '[ "self-hosted", "fast", "ARM64" ]'
+    runs-on: ${{ fromJSON(matrix.runner) }}
     name: "${{ matrix.os }},${{ matrix.board }}${{ matrix.extension }}"
     steps:
 

--- a/.github/workflows/build-armbian-sdk.yml
+++ b/.github/workflows/build-armbian-sdk.yml
@@ -36,6 +36,11 @@ jobs:
     name: "${{ matrix.os }},${{ matrix.board }}${{ matrix.extension }}"
     steps:
 
+      # cleaning self hosted runners: reset the workspace and ensure host
+      # dependencies (docker buildx, tree, apt/oci/ccache proxies) before building
+      - name: "Runner clean ${{ matrix.os }},${{ matrix.board }}${{ matrix.extension }}"
+        uses: armbian/actions/runner-clean@main
+
       - uses: armbian/build@main # main
         with:
           # mandatory

--- a/userpatches/config-armbian-sdk.conf
+++ b/userpatches/config-armbian-sdk.conf
@@ -13,13 +13,12 @@ declare -g COMPRESS_OUTPUTIMAGE="no"
 declare -g EXPERT="yes"
 declare -g KERNEL_BTF="yes"
 declare -g COMPRESS_OUTPUTIMAGE="sha,img,xz"
-# Ship the .iso and .img.qcow2 uncompressed (still checksummed). Both are
-# consumed as-is - the ISO is written/booted directly, the qcow2 is imported
-# straight into a hypervisor - so an .xz wrapper only forces an extra
-# decompress. The ISO's squashfs is already zstd-compressed (xz shaves ~3%),
-# and both formats sit under GitHub's 2 GiB asset cap uncompressed. The raw
-# .img keeps xz (SKIP_COMPRESSING matches the file's final extension only).
-declare -g SKIP_COMPRESSING="iso,qcow2"
+# Ship the .iso uncompressed (still checksummed): its squashfs is already
+# zstd-compressed so xz shaves ~3%, it's written/booted directly, and it sits
+# under GitHub's 2 GiB asset cap raw. The .img and .img.qcow2 keep xz - the raw
+# qcow2 is large enough that compression is worth the download savings.
+# (SKIP_COMPRESSING matches the file's final extension only.)
+declare -g SKIP_COMPRESSING="iso"
 declare -g IMAGE_XZ_COMPRESSION_RATIO=8
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-zsh,armbian-plymouth-theme"
 declare -g PREFER_DOCKER="yes"


### PR DESCRIPTION
Moves the SDK image builds to Armbian's own infra and adjusts compression accordingly.

### 1. Clean/prepare the self-hosted runners

Each `Matrix` build job now runs `armbian/actions/runner-clean@main` as its
first step, resetting the workspace and ensuring host dependencies (docker
buildx, tree, **mktorrent**, **gh**, apt/oci/ccache proxies) before
`armbian/build` runs.

> `gh` and `mktorrent` are added to `runner-clean` in **armbian/actions#39** —
> merge that first (`armbian/build` needs `gh api` for version resolution).

### 2. Move image builds to self-hosted runners

```yaml
- board: uefi-x86
  runner: '[ "self-hosted", "fast", "X64" ]'
- board: uefi-arm64
  runner: '[ "self-hosted", "fast", "ARM64" ]'
...
runs-on: ${{ fromJSON(matrix.runner) }}
```

`Keep` (keepalive) and `Aggregate` (manifest merge) stay on `ubuntu-latest`.

### 3. Re-enable qcow2 compression

`SKIP_COMPRESSING` drops back to **`"iso"`** (was `"iso,qcow2"`): the raw qcow2
is large enough that xz earns its keep, so it ships `.img.qcow2.xz` again. The
`.iso` stays uncompressed (already-compressed squashfs, written directly).

| output | after |
|---|---|
| `.img` | `.img.xz` |
| `.img.qcow2` | `.img.qcow2.xz` |
| `.iso` | raw |

Validated: workflow + config parse; runner strings resolve via `fromJSON` to
`[self-hosted, fast, X64]` / `[self-hosted, fast, ARM64]`; `SKIP_COMPRESSING="iso"`
leaves `.iso` raw while `.img`/`.img.qcow2` compress.

### ⚠️ Depends on
- **armbian/actions#39** (gh + mktorrent in runner-clean) — merge before this runs.
- Confirm **fast-labelled ARM64** runners exist (Armbian usually pairs `fast` with X64).