### PR TITLE
watchdog: scope to download-index (SDK retry moved to auto-retry-stalled)

### DIFF
--- a/.github/workflows/maintenance-watchdog-download-index.yml
+++ b/.github/workflows/maintenance-watchdog-download-index.yml
@@ -1,11 +1,16 @@
-name: "Maintenance: Watchdog"
-# Periodically poll the latest run of each watched workflow; if it
-# finished in 'failure' and hasn't already burned through the retry
-# budget, kick off rerun-failed-jobs. Catches transient network
-# breakage during apt/git/rsync/docker-pull steps that would
-# otherwise need manual intervention.
+name: "Maintenance: Watchdog (download-index)"
+# Periodically poll the latest run of the infrastructure-dispatch-download-index
+# workflow; if it finished in 'failure' and hasn't already burned through the
+# retry budget, kick off rerun-failed-jobs. Catches transient network breakage
+# during apt/git/rsync/docker-pull steps that would otherwise need manual
+# intervention.
 #
 # Same shape as armbian/docker-armbian-build's maintenance-watchdog.
+#
+# Scope: only infrastructure-dispatch-download-index. build-armbian-sdk has its
+# own event-driven retry in auto-retry-stalled.yml (fires on run completion,
+# with a systemic >50%-green guard); listing it here too would double-retry the
+# same failed run.
 on:
   schedule:
     - cron: '*/15 * * * *'
@@ -29,8 +34,8 @@ jobs:
       max-parallel: 4
       matrix:
         # Workflows to retry. Bare filename (without .yml).
+        # (build-armbian-sdk is handled by auto-retry-stalled.yml instead.)
         script:
-          - build-armbian-sdk
           - infrastructure-dispatch-download-index
 
     name: "${{ matrix.script }}"


### PR DESCRIPTION
Follow-up to the SDK auto-retry (#42): the two retry mechanisms overlapped on
`build-armbian-sdk`, so this splits their responsibilities cleanly.

- **Drop `build-armbian-sdk`** from the poll-based watchdog. It now has a
  dedicated, event-driven retry in `auto-retry-stalled.yml` (fires on run
  completion, retries only failed jobs, with a systemic `>50%-green` guard).
  Keeping it here too would **double-retry** the same failed run.
- The watchdog now covers only **`infrastructure-dispatch-download-index`**
  (which has no dedicated retry).
- **Renamed to match its purpose:**
  `maintenance-watchdog.yml` → `maintenance-watchdog-download-index.yml`, and
  the title `"Maintenance: Watchdog"` → `"Maintenance: Watchdog (download-index)"`.

Net result: `build-armbian-sdk` → `auto-retry-stalled.yml` (event-driven);
`infrastructure-dispatch-download-index` → this watchdog (15-min poll). No
workflow is retried by both.

YAML parses; matrix is now `[infrastructure-dispatch-download-index]`.